### PR TITLE
Fix audio chunking configuration and keep-audio functionality

### DIFF
--- a/main.py
+++ b/main.py
@@ -202,6 +202,7 @@ async def process_input(
                 format=output_format,
                 enable_correction=enable_correction,
                 use_ai_correction=use_ai_correction,
+                keep_audio=keep_audio,
                 enable_translation=enable_translation,
                 translation_target_language=target_lang,
                 whisper_source_language=whisper_source_language


### PR DESCRIPTION
## Summary
- Fix audio service to properly use configurable chunk size settings instead of hardcoded defaults
- Add support for configurable audio quality and mono output to reduce file sizes
- Fix keep-audio option for local video files by implementing missing parameter handling
- Implement proper audio file preservation in output directory when keep-audio flag is enabled

## Changes Made
### Audio Service Improvements
- Import settings configuration and use `max_chunk_size_mb` from environment variables
- Pass chunk size parameter correctly to splitting functions instead of using hardcoded 24MB default
- Add configurable audio quality and mono channel conversion for smaller output files

### Keep-Audio Functionality Fix  
- Add missing `keep_audio` parameter to `process_local_file` method signature
- Implement audio file copying to output directory when keep-audio option is enabled
- Fix parameter passing from main CLI to workflow service for local file processing

### Configuration Enhancements
- Support for AUDIO_QUALITY environment variable to control output bitrate
- Enable mono audio conversion (-ac 1) to reduce file size by ~50%
- Proper cleanup of temporary files while preserving requested audio files

## Test Plan
- [x] Verify chunking respects MAX_CHUNK_SIZE_MB environment setting
- [x] Test keep-audio option saves extracted audio to output directory  
- [x] Confirm mono audio conversion and configurable bitrate work correctly
- [x] Validate temporary file cleanup still functions properly
- [x] Test with various video file formats and sizes

## Related Issues
Addresses audio processing configuration issues and missing keep-audio functionality for local video file processing.

#31 