### PR TITLE
add: Add Source Language Selection to Translation Service

### DIFF
--- a/sogon/services/interfaces.py
+++ b/sogon/services/interfaces.py
@@ -79,7 +79,7 @@ class TranslationService(ABC):
         pass
     
     @abstractmethod
-    async def translate_transcription(self, transcription: TranscriptionResult, target_language: SupportedLanguage) -> TranslationResult:
+    async def translate_transcription(self, transcription: TranscriptionResult, target_language: SupportedLanguage, source_language: Optional[str] = None) -> TranslationResult:
         """Translate transcription with metadata preservation"""
         pass
     

--- a/sogon/services/translation_service.py
+++ b/sogon/services/translation_service.py
@@ -248,14 +248,16 @@ class TranslationServiceImpl(TranslationService):
     async def translate_transcription(
         self, 
         transcription: TranscriptionResult, 
-        target_language: SupportedLanguage
+        target_language: SupportedLanguage,
+        source_language: Optional[str] = None
     ) -> TranslationResult:
         """Translate transcription with metadata preservation"""
         try:
             start_time = time.time()
             
-            # Auto-detect source language
-            source_language = await self.detect_language(transcription.text)
+            # Use provided source language or auto-detect
+            if not source_language:
+                source_language = await self.detect_language(transcription.text)
             
             # Extract all segment texts for batch translation
             segment_texts = []

--- a/sogon/services/workflow_service.py
+++ b/sogon/services/workflow_service.py
@@ -314,7 +314,7 @@ class WorkflowServiceImpl(WorkflowService):
                 
                 target_language = SupportedLanguage(job.translation_target_language)
                 translation_result = await self.translation_service.translate_transcription(
-                    final_transcription, target_language
+                    final_transcription, target_language, job.whisper_source_language
                 )
                 
                 # Save translated version


### PR DESCRIPTION
- Add optional parameter for source language selection to the `translate_transcription` method
- Implement auto-detection when no source language is provided
- Provide the source language when the workflow service calls translation

close #33