### PR TITLE
fix: Update source_language type hint in Translation Service

### DIFF
--- a/sogon/services/translation_service.py
+++ b/sogon/services/translation_service.py
@@ -249,7 +249,7 @@ class TranslationServiceImpl(TranslationService):
         self, 
         transcription: TranscriptionResult, 
         target_language: SupportedLanguage,
-        source_language: Optional[str] = None
+        source_language: str | None = None
     ) -> TranslationResult:
         """Translate transcription with metadata preservation"""
         try:


### PR DESCRIPTION
- Change type hint for source_language parameter in translate_transcription method to support both string and None types.

close #36